### PR TITLE
Add Acceptance Test documentation for developers and testers

### DIFF
--- a/_docs/L-Developer-Portal/Quality-Assurance/Acceptance-Tests/Acceptance-Test-Structure.md
+++ b/_docs/L-Developer-Portal/Quality-Assurance/Acceptance-Tests/Acceptance-Test-Structure.md
@@ -1,0 +1,70 @@
+# Acceptance Test Structure
+
+## User Interface
+
+The scope for acceptance testing of the CluedIn user interface is defined in [GitHub Issue #981](https://github.com/CluedIn-io/CluedIn.Widget/issues/981).
+
+The acceptance test release scenarios are listed below with links to the related test scripts:
+
+1. App Root
+    * [Single Page Application](../test/acceptance/05.SinglePageApplication.feature)
+2. Login
+    * [Login](../test/acceptance/10.Login.feature)
+    * [Forgotten Password](../test/acceptance/20.ForgottenPassword.feature)
+3. Homescreen
+    * [Homescreen](../test/acceptance/70.Homescreen.feature)
+4. Integration
+    * [Integrations](../test/acceptance/75.Integrations.feature)
+    * [Integration Permissions](../test/acceptance/85.IntegrationPermissions.feature)
+5. Search
+    * [Simple Search](../test/acceptance/80.SimpleSearch.feature)
+6. Entity
+    * [Followed Entities](../test/acceptance/81.FollowedEntities.feature)
+7. Users
+    * [Users](../test/acceptance/82.Users.feature)
+    * [Invite New User](../test/acceptance/30.InviteNewUser.feature)
+    * [Manage Invites](../test/acceptance/60.ManageInvites.feature)
+8. Data Governance
+    * [Data Governance](../test/acceptance/84.DataGovernance.feature)
+9. Developer
+    * [Developer](../test/acceptance/85.Developer.feature)
+10. Settings
+    * [Settings](../test/acceptance/86.Settings.feature)
+11. Logout
+    * [Login](../test/acceptance/10.Login.feature)
+12. Follow
+    * [Followed Entities](../test/acceptance/81.FollowedEntities.feature)
+
+The following acceptance test scripts are currently unmapped to GitHub release scenario definitions:
+
+* [Single Page Application](../test/acceptance/05.SinglePageApplication.feature)
+* [Domain Signup](../test/acceptance/40.DomainSignup.feature)
+* [Change Password](../test/acceptance/50.ChangePassword.feature)
+
+## Customer Setup
+
+The following tests cover the tasks of setting CluedIn up for a new customer:
+
+* [Create Organization](../test/acceptance/07.CreateOrganization.feature)
+
+## API
+
+Acceptance tests covering the application API are provided in:
+
+* [API Dashboard](../test/acceptance/90.Api.Dashboard.feature)
+* [API Schema](../test/acceptance/91.Api.Schema.feature)
+
+## Non-Functional Requirements
+
+Non-functional acceptance tests scripts are provided for:
+
+* [Security](../test/acceptance/01.Security.feature)
+* [Logging](../test/acceptance/95.Logging.feature)
+
+## Related Documentation
+
+* [Acceptance Test Overview](Acceptance-Test.md)
+
+* [Running Acceptance Tests](Running-Acceptance-Tests.md)
+
+* [Tagging Acceptance Tests](Tagging-Acceptance-Tests.md)

--- a/_docs/L-Developer-Portal/Quality-Assurance/Acceptance-Tests/Acceptance-Test.md
+++ b/_docs/L-Developer-Portal/Quality-Assurance/Acceptance-Tests/Acceptance-Test.md
@@ -1,0 +1,24 @@
+# Acceptance Test
+
+Acceptance tests exercise application features on an end-to-end basis from the perspective of the user.
+
+* BDD Acceptance tests verify the behaviour and features in the running `CluedIn.App`.
+
+  Tests are defined using a `Given`, `When`, `Then` syntax `.feature` files in the `test\acceptance` folder. PowerShell `.steps.ps1` files in the `step_definitions` sub-folder contain the implementation details for these acceptance tests.
+
+  These tests are written in a [black box testing](https://en.wikipedia.org/wiki/Black-box_testing) style with limited direct access to internal infrastructure.
+
+## Acceptance Test Documentation
+
+* [Acceptance Test Structure](Acceptance-Test-Structure.md)
+
+* [Tagging Acceptance Tests](Tagging-Acceptance-Tests.md)
+
+* [Running Acceptance Tests](Running-Acceptance-Tests.md)
+
+### Tooling Used
+
+* [Docker](https://www.docker.com/)
+* [Dredd](https://dredd.org/)
+* [Pester](https://github.com/pester/Pester)
+* [Selenium](https://www.seleniumhq.org/)

--- a/_docs/L-Developer-Portal/Quality-Assurance/Acceptance-Tests/Running-Acceptance-Tests.md
+++ b/_docs/L-Developer-Portal/Quality-Assurance/Acceptance-Tests/Running-Acceptance-Tests.md
@@ -1,0 +1,75 @@
+# Running Acceptance Tests
+
+Acceptance tests are maintained within the `CluedIn.App` repository. When using the command line ensure that you are working within this repository.
+
+## Pre-Requisites
+
+In order to run acceptance tests in a local developer environment the following pre-requisites need to be met:
+
+1. SSL certificates are available in the `tools\pki\certs` folder of the `CluedIn` repository.
+
+   To generate SSL certificates required for the infrastructure run nthe following command as an Administrator and accept the certificate registrations when prompted to:
+
+   ```PowerShell
+   tools\pki\Create-Certificates.ps1
+   ```
+
+   The contents of the `tools\pki\certs` folder should be copied to the `CluedIn` repository when running with a local instance of the CluedIn server. From the `CluedIn.App` repository run the following command to copy the certificate files to the `CluedIn` repository folder:
+
+   ```PowerShell
+   copy .\tools\pki\certs\*.* ..\cluedin\tools\pki\certs\ -verbose -force
+   ```
+
+## Using Docker to run Acceptance Tests
+
+Acceptance tests are executed by:
+
+1. Follow instructions above to start the application
+1. Run ```docker-compose -f .\docker-compose.tests.yml -f .\docker-compose.yml up -d```
+1. You can follow the acceptance test results as they are executed: ```docker-compose -f .\docker-compose.tests.yml -f .\docker-compose.yml logs -f acceptance-tests```
+
+## Running Tests on a Local Machine
+
+You can also run the tests in bare-metal using a local browser (e.g. Chrome). Run the application normally (i.e. ```docker-compose up -d```)
+
+1. In a console window run:
+
+```Powershell
+test/acceptance/Set-TestEnvironment.ps1
+Invoke-Gherkin
+```
+
+You could also run the acceptance tests against the website running on bare metal (on port 5001):
+
+1. Start the website (F5 on Visual Studio or ```dotnet run --project src/Cluedin.App```)
+1. Run:
+
+```Powershell
+test/acceptance/Set-TestEnvironment.ps1 -TestUrl https://app.127.0.0.1.xip.io:5001
+Invoke-Gherkin
+```
+
+## Running Tests Against Hosted Sites
+
+To run the acceptance tests against a remotely hosted site set the `TestUrl` environment variable and invoke the test runner.
+
+For example, the following commands run only the tests marked with a `Passive` impact tag against the `foobar` organization setup in CluedIn's `release23` test environment:
+
+```PowerShell
+.\test\acceptance\Set-TestEnvironment.ps1 -TestUrl https://foobar.release23.cluedin-test.online -Driver Chrome
+Invoke-Gherkin -Tag Passive
+```
+
+The command below shows how to filter a test run by feature and scenario:
+
+```PowerShell
+Invoke-Gherkin .\test\acceptance\70.Homescreen.feature -ScenarioName 'Home menu navigation'
+```
+
+## Related Documentation
+
+* [Acceptance Test Overview](Acceptance-Test.md)
+
+* [Acceptance Test Structure](Acceptance-Test-Structure.md)
+
+* [Tagging Acceptance Tests](Tagging-Acceptance-Tests.md)

--- a/_docs/L-Developer-Portal/Quality-Assurance/Acceptance-Tests/Tagging-Acceptance-Tests.md
+++ b/_docs/L-Developer-Portal/Quality-Assurance/Acceptance-Tests/Tagging-Acceptance-Tests.md
@@ -1,0 +1,103 @@
+# Tagging Acceptance Tests
+
+Tags specified in Pester acceptance scripts are used to both indicate test dependencies and offer a means to control which tests execute.
+
+> A tag allows a developer to organize their tests based on different criteria and execute those tests accordingly. Tags allow a developer to manage large test suites that may take hours to run by only executing certain tests matching certain tags.
+
+## Tag Categories
+
+Tags used in the acceptance tests can be categorized as follows:
+
+* Tags that show the impact on the target environment of running the test
+
+* Tags that document test dependencies and requirements
+
+* Tags that document actions performed when running the test
+
+* Tags that are solely used to filter which tests are executed in a particular run.
+
+The list of tags for each of these categories are documented below in the following sections.
+
+### Test Impact Tags
+
+Tags can be used to indicate the impact of an acceptance test.
+
+The following tags are recommended:
+
+* _@Passive_
+
+  The test performs read-only interactions with the target environment.
+
+  This tag is optional.
+
+* _@Safe_
+
+  The test performs updates on data in the target environment that can be considered non-destructive.
+
+  For example, a test that adds and then removes an integration component on a shared target environment should be marked with the `@Safe` tag.
+
+* _@Active_
+
+  The test performs updates on data in the target environment that can be considered destructive.
+
+  For example, a test that changed a user's UI `Settings` on a shared target environment should be marked with the `@Active` tag.
+
+__Note:__ Care should be taken to not run tests marked with a `@Active` tag against shared test environments.
+
+### Tags Indicating Test Dependencies
+
+The following tags can be used to specify pre-requisites for an acceptance test:
+
+<!-- * _@Dredd_
+
+  Test uses the `Dredd` command-line tool for validating API description document against a running backend instance of the application API.
+
+  Not implemented -->
+
+* _@Fullstack_
+
+  Test requires the full CluedIn application stack to be running and available
+
+* _@Selenium_
+
+  Test utilises Selenium browser automation
+
+* _@WithData_
+
+  Test requires CluedIn application stack containing data.
+
+### Tags Indication Test Actions
+
+Actions performed by tests can be categorized with the following tags:
+
+* _@Email_
+
+  Test causes e-mail to be sent.
+
+### Test Execution Control Tags
+
+* _@Api_
+
+  Selects tests validating the application API.
+
+* _@CuttingConcerns_
+
+  Select tests that should be executed after other acceptance tests have run.
+
+* _@Logging_
+
+  Selects tests validating the application logs.
+
+* _@Security_
+
+  Selects tests checking the security concerns of the application and it's users.
+
+## Related Documentation
+
+* [Acceptance Test Overview](Acceptance-Test.md)
+
+* [Acceptance Test Structure](Acceptance-Test-Structure.md)
+
+* [Running Acceptance Tests](Running-Acceptance-Tests.md)
+
+* [Using Tags In PowerShell Pester For Unit Testing](https://blog.ipswitch.com/how-to-use-tags-in-a-powershell-pester-test)


### PR DESCRIPTION
PR adds the following documentation for Acceptance Tests:

* Test scope for release 2.3 mapped to test feature files covering these requirements
* Instructions on running tests against both local and remote websites
* Conventions for use of Pester _Tags_ to categorize and filter which tests get executed