### PR TITLE
 fixed 3.3.0 and up chart example

### DIFF
--- a/docs/kb/kb0006-sso-auth-clean.md
+++ b/docs/kb/kb0006-sso-auth-clean.md
@@ -112,4 +112,4 @@ From 3.3.0 a new chart `cluedin/cluedin-platform` is used to support improved fl
     helm upgrade -f values.yaml cluedin cluedin/cluedin-platform
     ```
 
-For additonal configuration options, see: https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview/
+For additional configuration options, see: https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview/


### PR DESCRIPTION
- uses extraConfiguration rather than environment (see https://github.com/CluedIn-io/CluedIn.Deploy.Helm/blob/ae9042f70e6b5f34e4c83015ef8a145e164c142f/charts/cluedin-application/values.yaml#L595)