### PR TITLE
docs: Update AMA to Marketplace for backup title and link fixes

### DIFF
--- a/docs/020-deployment.md
+++ b/docs/020-deployment.md
@@ -8,14 +8,14 @@ permalink: /deployment
 
 {: .fs-6 .fw-300 }
 
-CluedIn is designed with the [Microservices Architecture](https://microservices.io/index.html) in mind. That means that CluedIn, as an application, is a set of interconnected services: a web application, GraphQL API, databases, message queue, and so on.
+CluedIn is designed with the [Microservices Architecture](https://microservices.io/index.html) in mind. That means that CluedIn, as an application, is a set of interconnected services: a web application, GraphQL API, databases, message queues, and so on.
 
 Each CluedIn service runs in a separate [container](https://www.docker.com/get-started), allowing us to test, scale, and monitor each service effectively.
 
 While CluedIn is a [cloud-native](https://docs.microsoft.com/en-us/dotnet/architecture/cloud-native/definition) application, you can also run it on your local machine.
 
-[Docker Compose](https://docs.docker.com/compose/) is the technology that allows us to run a group of containers on our local computer easily. You just run a few commands, and a new CluedIn instance is up and running on your laptop or desktop computer. You can use it for testing and development. Please, follow the [Local Deployment](./docker-compose) section for more details.
+[Docker Compose](https://docs.docker.com/compose/) is the technology that allows us to run a group of containers on our local computer easily. You just run a few commands, and a new CluedIn instance is up and running on your laptop or desktop computer. You can use it for testing and development. Please, follow the [Local Deployment](/deployment/local/step-2) section for more details.
 
 When it comes to production, [Kubernetes](https://kubernetes.io/) runs CluedIn services in the cloud and ensures that the containers are healthy and scale as they should.
 
-While all modern cloud providers support Kubernetes, we recommend running CluedIn on Microsoft Azure with the help of [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/). Read more about it in the [Azure](./azure) section of our documentation. 
+While all modern cloud providers support Kubernetes, we recommend running CluedIn on Microsoft Azure with the help of [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/). Read more about it in the [Azure](/deployment/azure-marketplace) section of our documentation. 

--- a/docs/020-deployment/howtos/113-ama-backup.md
+++ b/docs/020-deployment/howtos/113-ama-backup.md
@@ -4,7 +4,7 @@ nav_order: 15
 parent: How-to guides
 grand_parent: Installation
 permalink: /deployment/infra-how-tos/ama-backup
-title: AMA backup and restore
+title: Marketplace backup and restore
 tags: ["deployment", "ama", "marketplace", "azure", "backup"]
 last_modified: 2023-11-08
 ---


### PR DESCRIPTION
## Description
- Update 'AMA' to 'Marketplace' for the backup and restore document title
- Fixes broken links on /deployment file