### PR TITLE
Docs: Fix github port and add letsencrypt

### DIFF
--- a/docs/020-deployment/howtos/100-configure-firewall.md
+++ b/docs/020-deployment/howtos/100-configure-firewall.md
@@ -19,9 +19,10 @@ To do that, add the following rules to your Azure Firewall as described in the t
 |--|--|--|
 | `cluedinprod.azurecr.io` | 443 | CluedIn container registry |
 | `api.nuget.org` | 443 | NuGet packages |
-| `github.com` | 433 | GitHub artifacts |
+| `github.com` | 443 | GitHub artifacts |
 | `billing.cluedin.com` | 443 | CluedIn licensing server |
 | `*.grafana.com` | 443 | Grafana chart content |
 | `mcr.microsoft.com` | 443 | Microsoft container registry |
+| `acme-v02.api.letsencrypt.org` | 443 | (*optional*) LetsEncrypt service. Only required if not supplying own certificate |
 
 **Important!** If the rules have not been added, the installation will fail.


### PR DESCRIPTION
## Description
* Corrects github port from 433 to 443. 
* Adds LetsEncrypt fqdn to the list with optional tag in description