### PR TITLE
feat: Add basic page for Defender for Cloud recommendations

### DIFF
--- a/docs/kb/kb1003-defender.md
+++ b/docs/kb/kb1003-defender.md
@@ -24,7 +24,7 @@ The default security policies that are set on `Microsoft Defender for Cloud` can
 
 The CluedIn installation installs an Azure Kubernetes Service (AKS) cluster which pulls images from `cluedinprod.azurecr.io` with an authorization token. Because `cluedinprod.azurecr.io` is external to your environment, it gets flagged by this recommendation when using default baseline advisories.
 
-**Solution**:
+**Solution**
 
 To resolve this issue, please amend the recommendation under remediation steps and add a regex string that can accomodate the CluedIn registry.
 An example is: `^cluedinprod\.azurecr\.io.*$`. 

--- a/docs/kb/kb1003-defender.md
+++ b/docs/kb/kb1003-defender.md
@@ -1,0 +1,32 @@
+---
+layout: cluedin
+title: 'Microsoft Defender for Cloud recommendations'
+permalink: /kb/defender-for-cloud-recommendations
+nav_exclude: true
+tags: ["recommendations", "Defender", "Cloud"]
+is_kb: true
+---
+
+## On this page
+{: .no_toc .text-delta }
+1. TOC
+{:toc}
+
+This document covers Microsoft Defender for Cloud advisories that you may face when installing the CluedIn MDM PaaS variant of the product into your environemnt. It will explain what each advisory means and how to potentially resolve the issue.
+
+If the advisory is not listed below, please do reach out to support@cluedin.com who will be able to advise further.
+
+## Recommendations
+
+### Container images should be deployed from trusted registries only
+
+The default security policies that are set on `Microsoft Defender for Cloud` can be quite bare when it comes out of the box. As a result, this particular recommendation gets flagged frequently as a High risk. 
+
+The CluedIn installation installs an Azure Kubernetes Service (AKS) cluster which pulls images from `cluedinprod.azurecr.io` with an authorization token. Because `cluedinprod.azurecr.io` is external to your environment, it does get flagged by this recommendation when using default baseline advisories.
+
+**Solution**:
+
+To resolve this issue, please amend the recommendation under remediation steps and add a regex string that can accomodate the CluedIn registry.
+An example is: `^cluedinprod\.azurecr\.io.*$`. 
+
+**NOTE**: This will affect all AKS clusters. If you have additional AKS clusters which are for internal services or other products, you may want to use a more loosely defined regex string that can accomodate both CluedIn and other third-party registries. 

--- a/docs/kb/kb1003-defender.md
+++ b/docs/kb/kb1003-defender.md
@@ -22,7 +22,7 @@ If the advisory is not listed below, please do reach out to support@cluedin.com 
 
 The default security policies that are set on `Microsoft Defender for Cloud` can be quite bare when it comes out of the box. As a result, this particular recommendation gets flagged frequently as a high risk. 
 
-The CluedIn installation installs an Azure Kubernetes Service (AKS) cluster which pulls images from `cluedinprod.azurecr.io` with an authorization token. Because `cluedinprod.azurecr.io` is external to your environment, it does get flagged by this recommendation when using default baseline advisories.
+The CluedIn installation installs an Azure Kubernetes Service (AKS) cluster which pulls images from `cluedinprod.azurecr.io` with an authorization token. Because `cluedinprod.azurecr.io` is external to your environment, it gets flagged by this recommendation when using default baseline advisories.
 
 **Solution**:
 

--- a/docs/kb/kb1003-defender.md
+++ b/docs/kb/kb1003-defender.md
@@ -20,7 +20,7 @@ If the advisory is not listed below, please do reach out to support@cluedin.com 
 
 ### Container images should be deployed from trusted registries only
 
-The default security policies that are set on `Microsoft Defender for Cloud` can be quite bare when it comes out of the box. As a result, this particular recommendation gets flagged frequently as a High risk. 
+The default security policies that are set on `Microsoft Defender for Cloud` can be quite bare when it comes out of the box. As a result, this particular recommendation gets flagged frequently as a high risk. 
 
 The CluedIn installation installs an Azure Kubernetes Service (AKS) cluster which pulls images from `cluedinprod.azurecr.io` with an authorization token. Because `cluedinprod.azurecr.io` is external to your environment, it does get flagged by this recommendation when using default baseline advisories.
 

--- a/docs/kb/kb1003-defender.md
+++ b/docs/kb/kb1003-defender.md
@@ -29,4 +29,5 @@ The CluedIn installation installs an Azure Kubernetes Service (AKS) cluster whic
 To resolve this issue, please amend the recommendation under remediation steps and add a regex string that can accomodate the CluedIn registry.
 An example is: `^cluedinprod\.azurecr\.io.*$`. 
 
-**NOTE**: This will affect all AKS clusters. If you have additional AKS clusters which are for internal services or other products, you may want to use a more loosely defined regex string that can accomodate both CluedIn and other third-party registries. 
+{:.important}
+This will affect all AKS clusters. If you have additional AKS clusters which are for internal services or other products, you may want to use a more loosely defined regex string that can accommodate both CluedIn and other third-party registries. 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
- Adds the start of a page with the main recommendation explained:
   `Container images should be deployed from trusted registries only`
Work Item ID: AB#


## How has it been tested? <!-- Remove if not needed -->


## Release Note <!-- Remove if not needed -->


## Notable Changes <!-- Remove if not needed -->
