### PR TITLE
Fixed permalinks in paas operations articles (existing)

### DIFF
--- a/docs/020-deployment/ama/030-ama-second-step.md
+++ b/docs/020-deployment/ama/030-ama-second-step.md
@@ -190,7 +190,7 @@ Your Azure Firewall should cover the following:
 - **Default AKS functionality** – logs and pods should be able to see Kubernetes API Server (as recommended in <a href="https://learn.microsoft.com/en-us/azure/aks/outbound-rules-control-egress">Outbound network and FQDN rules for AKS clusters</a>).
 - **CluedIn resource access** – resources needed for the CluedIn installation.
 
-For the list of firewall rules that should be added to your Azure Firewall, see [Configure firewall](/paas-operations/configuration/configure-firewall).
+For the list of firewall rules that should be added to your Azure Firewall, see [Configure firewall](/deployment/infra-how-tos/configure-firewall).
 
 {:.important}
 If the rules have not been added, the installation will fail.
@@ -217,7 +217,7 @@ The deployed Azure Kubernetes Service is deployed with a single Azure Load Balan
 
 If you would like support on this, please reach out to one of CluedIn's infrastructure engineers to assist you with this change.
 
-More information regarding networking can be found in<a href="/paas-operations/configuration/advanced-network"> Advanced network configuration</a>.
+More information regarding networking can be found in<a href="/deployment/infra-how-tos/advanced-network"> Advanced network configuration</a>.
 
 ## Analyze Azure policies and tagging
 

--- a/docs/020-deployment/ama/050-ama-fourth-step.md
+++ b/docs/020-deployment/ama/050-ama-fourth-step.md
@@ -25,21 +25,21 @@ If you did not set up CluedIn PaaS with a custom DNS, you may experience issues 
 
 To avoid interruption in the adoption of CluedIn, external DNS names are provided by the <a href="https://sslip.io/">sslip.io</a> service by default without any upfront configuration. The sslip.io service is a DNS service that returns the IP address when queried with a host name that contains an embedded IP address.
 
-The default DNS configuration ensures security by using the Automated Certificate Management Environment (ACME) protocol to issue SSL Certificates via the HTTP challenge method. For more information about certificates, see [Configure certificates](/paas-operations/configuration/configure-certificates).
+The default DNS configuration ensures security by using the Automated Certificate Management Environment (ACME) protocol to issue SSL Certificates via the HTTP challenge method. For more information about certificates, see [Configure certificates](/deployment/infra-how-tos/configure-certificates).
 
-If you want to set up custom DNS entries, see [Configure DNS](/paas-operations/configuration/configure-dns).
+If you want to set up custom DNS entries, see [Configure DNS](/deployment/infra-how-tos/configure-dns).
 
 ## Configure custom SSL certificates
 
-By default, CluedIn installation is secured by using TLS. CluedIn uses the Automated Certificate Management Environment (ACME) protocol and the public Let's Encrypt certificate authority to issue certificates. However, this default configuration might not comply with your organization's security policy. If you want to use a Subject Alternative Name (SAN) or wildcard certificate for you domain, see [Configure certificates](/paas-operations/configuration/configure-certificates).
+By default, CluedIn installation is secured by using TLS. CluedIn uses the Automated Certificate Management Environment (ACME) protocol and the public Let's Encrypt certificate authority to issue certificates. However, this default configuration might not comply with your organization's security policy. If you want to use a Subject Alternative Name (SAN) or wildcard certificate for you domain, see [Configure certificates](/deployment/infra-how-tos/configure-certificates).
 
 ## Configure alerts
 
-By default, CluedIn contains built-in alerts that are sent to our support team. You can configure your own alerts in the Azure portal. For more information about alerts, see [Configure alerts](/paas-operations/configuration/configure-alerts).
+By default, CluedIn contains built-in alerts that are sent to our support team. You can configure your own alerts in the Azure portal. For more information about alerts, see [Configure alerts](/deployment/infra-how-tos/configure-alerts).
 
 ## Configure logging
 
-CluedIn uses structured logging, and only the console sink is enabled by default. If you want to use another sink, see [Configure logging](/paas-operations/configuration/configure-logging).
+CluedIn uses structured logging, and only the console sink is enabled by default. If you want to use another sink, see [Configure logging](/deployment/infra-how-tos/configure-logging).
 
 By default, your CluedIn containers are configured to log at the production level. The production log level allows you to view high-level information about the server and the tasks it is performing. The production log level provides an output with the following log entry types:
 
@@ -50,11 +50,11 @@ By default, your CluedIn containers are configured to log at the production leve
 
 ## Set up SSO
 
-CluedIn does not set up SSO directly out of the box. If you want to use SSO, see [Configure SSO](/paas-operations/configuration/configure-sso).
+CluedIn does not set up SSO directly out of the box. If you want to use SSO, see [Configure SSO](/deployment/infra-how-tos/configure-sso).
 
 ## Set up a backup solution
 
-Currently, a backup solution is a post-install step because Microsoft does not support the ability to deploy backup policies within AMA. To set up a backup solution, see [AMA backup and restore](/paas-operations/ama-backup).
+Currently, a backup solution is a post-install step because Microsoft does not support the ability to deploy backup policies within AMA. To set up a backup solution, see [AMA backup and restore](/deployment/infra-how-tos/ama-backup).
 
 ## Results
 
@@ -64,4 +64,4 @@ At this point, your CluedIn instance is up and running and configured according 
 
 Review procedures for basic maintenance operations:
 
-- [Connect to CluedIn cluster using Azure Cloud Shell](/paas-operations/configuration/connect-to-cluedin)
+- [Connect to CluedIn cluster using Azure Cloud Shell](/deployment/infra-how-tos/connect-to-cluedin)

--- a/docs/020-deployment/azure/setup/010-step-by-step-install.md
+++ b/docs/020-deployment/azure/setup/010-step-by-step-install.md
@@ -282,6 +282,6 @@ Below you will find some useful links on achieving the above:
 - [Install a crawler/custom component](/integration/install-integrations)
 
 Optionally, you can also adjust other settings to cater for more complex scenarios:
-- [Persistence/Using Managed Disks](/paas-operations/configuration/pvc)
-- [Azure SQL Server](/paas-operations/configuration/sql)
+- [Persistence/Using Managed Disks](/deployment/kubernetes/persistence)
+- [Azure SQL Server](/deployment/kubernetes/sql)
 - [Scaling](/deployment/kubernetes/scaling)

--- a/docs/020-deployment/azure/setup/020-full-azure-cli-install.md
+++ b/docs/020-deployment/azure/setup/020-full-azure-cli-install.md
@@ -46,6 +46,6 @@ Below you will find some useful links on achieving the above:
 - [Install a crawler/custom component](/integration/install-integrations)
 
 Optionally, you can also adjust other settings to cater for more complex scenarios:
-- [Persistence/Using Managed Disks](/paas-operations/configuration/pvc)
-- [Azure SQL Server](/paas-operations/configuration/sql)
+- [Persistence/Using Managed Disks](/deployment/kubernetes/persistence)
+- [Azure SQL Server](/deployment/kubernetes/sql)
 - [Scaling](/deployment/kubernetes/scaling)

--- a/docs/030-administration/010-user-management.md
+++ b/docs/030-administration/010-user-management.md
@@ -61,7 +61,7 @@ The following diagram shows the flow of adding users to CluedIn.
 
 ### Add user via SSO
 
-If you have Azure Active Directory SSO enabled for CluedIn, the users will be able to sign in using SSO. For more information, see [Configure SSO](/paas-operations/configuration/configure-sso). 
+If you have Azure Active Directory SSO enabled for CluedIn, the users will be able to sign in using SSO. For more information, see [Configure SSO](/deployment/infra-how-tos/configure-sso). 
 
 ## Deactivate user
 

--- a/docs/190-paas-operations/001-architecture.md
+++ b/docs/190-paas-operations/001-architecture.md
@@ -8,10 +8,6 @@ tags: ["deployment", "ama", "marketplace", "azure", "architecture"]
 last_modified: 2023-11-08
 headerIcon: "paas"
 ---
-## On this page
-{: .no_toc .text-delta }
-1. TOC
-{:toc}
 
 Below is a high-level design of what gets deployed from the Azure Marketplace Application (AMA) wizard and what you can expect after installing the product. 
 

--- a/docs/190-paas-operations/001-architecture.md
+++ b/docs/190-paas-operations/001-architecture.md
@@ -17,4 +17,4 @@ Below is a high-level design of what gets deployed from the Azure Marketplace Ap
 
 ![cluedin-architecture-hlsd.png](../../assets/diagrams/cluedin-architecture-hlsd.png)
 
-For a detailed design surrounding the networking, please visit [Advanced network configuration](/paas-operations/configuration/advanced-network)
+For a detailed design surrounding the networking, please visit [Advanced network configuration](/deployment/infra-how-tos/advanced-network)

--- a/docs/190-paas-operations/002-backup-and-restore.md
+++ b/docs/190-paas-operations/002-backup-and-restore.md
@@ -2,7 +2,7 @@
 layout: cluedin
 nav_order: 2
 parent: PaaS operations
-permalink: /paas-operations/ama-backup
+permalink: /deployment/infra-how-tos/ama-backup
 title: Backup and restore
 tags: ["deployment", "ama", "marketplace", "azure", "backup"]
 last_modified: 2024-05-09

--- a/docs/190-paas-operations/configuration/010-connect-to-cluedin.md
+++ b/docs/190-paas-operations/configuration/010-connect-to-cluedin.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 1
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/connect-to-cluedin
+permalink: /deployment/infra-how-tos/connect-to-cluedin
 title: Connect to CluedIn cluster
 tags: ["deployment", "ama", "marketplace", "azure"]
 last_modified: 2023-06-20

--- a/docs/190-paas-operations/configuration/020-setup-sso.md
+++ b/docs/190-paas-operations/configuration/020-setup-sso.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 2
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/configure-sso
+permalink: /deployment/infra-how-tos/configure-sso
 title: SSO
 tags: ["deployment", "ama", "marketplace", "azure"]
 last_modified: 2024-02-29
@@ -32,7 +32,7 @@ Configuring SSO for CluedIn using Microsoft Entra involves two main steps:
 
 1. [Create Kubernetes secret and enable SSO via Helm](#create-kubernetes-secret-and-enable-sso-via-helm)
 
-**Important!** Before configuring SSO, make sure that you have configured [DNS](/paas-operations/configuration/configure-dns) and [TLS](/paas-operations/configuration/configure-certificates).
+**Important!** Before configuring SSO, make sure that you have configured [DNS](/deployment/infra-how-tos/configure-dns) and [TLS](/deployment/infra-how-tos/configure-certificates).
 
 ## Register an application in the Azure portal
 
@@ -242,7 +242,7 @@ After you complete the Azure application registration and app roles configuratio
 
 - You should be comfortable working in either PowerShell or bash terminal via Azure Cloud Shell.
 
-- You should be connected to your AKS cluster. See [Connect to CluedIn cluster](/paas-operations/configuration/connect-to-cluedin) for detailed instructions.
+- You should be connected to your AKS cluster. See [Connect to CluedIn cluster](/deployment/infra-how-tos/connect-to-cluedin) for detailed instructions.
 
 - Your Helm repository is set up.
 

--- a/docs/190-paas-operations/configuration/030-advanced-network.md
+++ b/docs/190-paas-operations/configuration/030-advanced-network.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 3
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/advanced-network
+permalink: /deployment/infra-how-tos/advanced-network
 title: Advanced network configuration
 tags: ["deployment", "ama", "marketplace", "azure"]
 last_modified: 2024-03-01
@@ -28,7 +28,7 @@ The following diagram shows the advanced network configuration of CluedIn.
 
 ![ama-network-2.jpeg](../../assets/images/ama/howtos/advanced-network-2.jpeg)
 
-Advanced network configuration requires that you have set up the firewall policy. For more information, see [Configure firewall](/paas-operations/configuration/configure-firewall).
+Advanced network configuration requires that you have set up the firewall policy. For more information, see [Configure firewall](/deployment/infra-how-tos/configure-firewall).
 
 Advanced network configuration (ingress vNet integration) allows you to specify the vNet and/or subnet address spaces that will be used to deploy your CluedIn platform. If you are deploying into your own network, see the following Microsoft guidelines for planning your Kubernetes networking model:
 
@@ -44,9 +44,9 @@ CluedIn can operate inside CIDR /23 with 510 available IP addresses. However, th
 ### Advanced network configuration options
 
 **Important!** If you do not plan to make any changes to the default out-of-the-box network configuration, you can skip this section and check other configuration-related topics:
-- [Configure SSO](/paas-operations/configuration/configure-sso)
-- [Configure DNS](/paas-operations/configuration/configure-dns)
-- [Configure certificates](/paas-operations/configuration/configure-certificates)
+- [Configure SSO](/deployment/infra-how-tos/configure-sso)
+- [Configure DNS](/deployment/infra-how-tos/configure-dns)
+- [Configure certificates](/deployment/infra-how-tos/configure-certificates)
 
 When installing CluedIn from the Azure Marketplace, you can set up advanced network configuration on the **CluedIn - Advanced Configuration** tab. You can choose from the three networking options:
 
@@ -108,7 +108,7 @@ This section contains a procedure for configuring CluedIn to use your internal l
 **Prerequisites**
 
 - You should be comfortable working in either PowerShell or bash terminal via Azure Cloud Shell.
-- You should be connected to your AKS cluster. See [Connect to CluedIn cluster](/paas-operations/configuration/connect-to-cluedin) for detailed instructions.
+- You should be connected to your AKS cluster. See [Connect to CluedIn cluster](/deployment/infra-how-tos/connect-to-cluedin) for detailed instructions.
 - Your Helm repository is set up.
 
 If you have any questions, you can request CluedIn support by sending an email to <a href="mailto:support@cluedin.com">support@cluedin.com</a> (or reach out to your delivery manager if you have a committed deal).

--- a/docs/190-paas-operations/configuration/040-configure-email.md
+++ b/docs/190-paas-operations/configuration/040-configure-email.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 4
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/configure-email
+permalink: /deployment/infra-how-tos/configure-email
 title: Email
 tags: ["deployment", "kubernetes", "email"]
 headerIcon: "paas"

--- a/docs/190-paas-operations/configuration/050-configure-logging.md
+++ b/docs/190-paas-operations/configuration/050-configure-logging.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 5
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/configure-logging
+permalink: /deployment/infra-how-tos/configure-logging
 title: Logging
 tags: ["deployment", "ama", "marketplace", "azure"]
 last_modified: 2023-06-20

--- a/docs/190-paas-operations/configuration/070-configure-certificates.md
+++ b/docs/190-paas-operations/configuration/070-configure-certificates.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 7
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/configure-certificates
+permalink: /deployment/infra-how-tos/configure-certificates
 title: TLS certificates
 tags: ["deployment", "ama", "marketplace", "azure", "tls", "ssl", "certificates"]
 last_modified: 2023-06-20
@@ -23,7 +23,7 @@ In this article, you will learn how to create your own certificates and keys and
 **Prerequisites**
 
 - You should be comfortable working in either PowerShell or bash terminal via Azure Cloud Shell.
-- You should be connected to your AKS cluster. See [Connect to CluedIn cluster](/paas-operations/configuration/connect-to-cluedin) for detailed instructions.
+- You should be connected to your AKS cluster. See [Connect to CluedIn cluster](/deployment/infra-how-tos/connect-to-cluedin) for detailed instructions.
 - Your Helm repository is set up.
 
 If you have any questions, you can request CluedIn support by sending an email to <a href="mailto:support@cluedin.com">support@cluedin.com</a> (or reach out to your delivery manager if you have a committed deal).
@@ -34,7 +34,7 @@ If you want to use a Subject Alternative Name (SAN) or wildcard certificate for 
 
 **CSR requirements**
 
-The following FQDN are a requirement in order for the application to function correctly. In the example below, we use a dev environment. Your subdomains (app-dev, clean-dev) may differ and should match what is set in the DNS section of your values file. If you are unsure, please view the [`Configure DNS`](/paas-operations/configuration/configure-dns) page.
+The following FQDN are a requirement in order for the application to function correctly. In the example below, we use a dev environment. Your subdomains (app-dev, clean-dev) may differ and should match what is set in the DNS section of your values file. If you are unsure, please view the [`Configure DNS`](/deployment/infra-how-tos/configure-dns) page.
 
 **SAN**
 ```

--- a/docs/190-paas-operations/configuration/080-configure-dns.md
+++ b/docs/190-paas-operations/configuration/080-configure-dns.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 8
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/configure-dns
+permalink: /deployment/infra-how-tos/configure-dns
 title: DNS
 tags: ["deployment", "ama", "marketplace", "azure"]
 last_modified: 2023-06-20
@@ -64,7 +64,7 @@ After you add the needed DNS entries, update your DNS configuration for CluedIn.
 - You should be comfortable working in either PowerShell or bash terminal via Azure Cloud Shell.
 - You should be connected to your AKS cluster.
 
-    See [Connect to CluedIn cluster](/paas-operations/configuration/connect-to-cluedin) for detailed instructions.
+    See [Connect to CluedIn cluster](/deployment/infra-how-tos/connect-to-cluedin) for detailed instructions.
 
 - Your Helm repository is set up.
 
@@ -123,4 +123,4 @@ After a short time, you'll see the confirmation of your update in the console. C
 ![configure-dns-2.png](../../assets/images/ama/howtos/configure-dns-2.png)
 
 {:.important}
-This will use the LetsEncrypt service in the cluster to do an HTTP request to validate the certificate. If you would like to use a self-provided certificate, please review the [Configure TLS Certificates](/paas-operations/configuration/configure-certificates) page.
+This will use the LetsEncrypt service in the cluster to do an HTTP request to validate the certificate. If you would like to use a self-provided certificate, please review the [Configure TLS Certificates](/deployment/infra-how-tos/configure-certificates) page.

--- a/docs/190-paas-operations/configuration/081-configure-pvc.md
+++ b/docs/190-paas-operations/configuration/081-configure-pvc.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 9
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/pvc
+permalink: /deployment/kubernetes/persistence
 title: PVC
 tags: ["deployment", "kubernetes", "persistence"]
 headerIcon: "paas"

--- a/docs/190-paas-operations/configuration/090-configure-alerts.md
+++ b/docs/190-paas-operations/configuration/090-configure-alerts.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 10
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/configure-alerts
+permalink: /deployment/infra-how-tos/configure-alerts
 title: Alerts
 tags: ["deployment", "ama", "marketplace", "azure"]
 last_modified: 2023-06-23

--- a/docs/190-paas-operations/configuration/100-configure-firewall.md
+++ b/docs/190-paas-operations/configuration/100-configure-firewall.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 11
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/configure-firewall
+permalink: /deployment/infra-how-tos/configure-firewall
 title: Firewall
 tags: ["deployment", "ama", "marketplace", "azure"]
 last_modified: 2023-06-23

--- a/docs/190-paas-operations/configuration/110-ama-upgrade.md
+++ b/docs/190-paas-operations/configuration/110-ama-upgrade.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 12
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/ama-upgrade
+permalink: /deployment/infra-how-tos/ama-upgrade
 title: Marketplace upgrade
 tags: ["deployment", "ama", "marketplace", "azure"]
 last_modified: 2023-10-06

--- a/docs/190-paas-operations/configuration/114-configure-sqlserver.md
+++ b/docs/190-paas-operations/configuration/114-configure-sqlserver.md
@@ -3,7 +3,7 @@ layout: cluedin
 nav_order: 16
 parent: Configuration
 grand_parent: PaaS operations
-permalink: /paas-operations/configuration/sql
+permalink: /deployment/kubernetes/sql
 title: SQL Server
 tags: ["deployment", "kubernetes", "sqlserver"]
 headerIcon: "paas"


### PR DESCRIPTION
Fixed permalinks in PaaS operations articles so that links outside the doc portal or links that users saved redirect to the correct articles.