### PR TITLE
Higing the sync-aks-to-akv article

### DIFF
--- a/docs/190-paas-operations/008-akv2aks.md
+++ b/docs/190-paas-operations/008-akv2aks.md
@@ -7,6 +7,7 @@ tags: ["kubernetes","azure","aks", "akv", "key-vault", "azure"]
 last_modified: 2024-02-05
 nav_order: 8
 headerIcon: "paas"
+nav_exclude: true
 ---
 ## On this page
 {: .no_toc .text-delta }


### PR DESCRIPTION
Excluding the article "Sync certificates and secrets from AKV to AKS" from navigation. Whilst it's in our product, we don't 100% support it just yet.