### PR TITLE
Changed nodes to modes for server

### DIFF
--- a/docs/190-paas-operations/110-common-questions.md
+++ b/docs/190-paas-operations/110-common-questions.md
@@ -32,7 +32,7 @@ CluedIn is composed by 5 main containers:
 - Submitter
 - Server
 
-The server can operate across multiple nodes. For example, it can be setup to be a Web API, a processing box, or a streaming box. By default, your configuration will have 2 pods running as a Web API and 2 pods running as a processing box. Generally, this configuration is sufficient for 90% of the use cases we face. The following screenshot shows an example of nodes running in production.
+The server can operate across multiple modes. For example, it can be setup to be a Web API, a processing box, or a streaming box. By default, your configuration will have 2 pods running as a Web API and 2 pods running as a processing box. Generally, this configuration is sufficient for 90% of the use cases we face. The following screenshot shows an example of nodes running in production.
 
 ![nodes-in-production.png](../../assets/images/paas-operations/nodes-in-production.png)
 


### PR DESCRIPTION
[PaaS operations] Common questions: changes "nodes" to "modes" in "server can operate across different modes".