### PR TITLE
chore: Update the location of the migration script downloads

### DIFF
--- a/docs/190-paas-operations/007-configuration-migration.md
+++ b/docs/190-paas-operations/007-configuration-migration.md
@@ -27,11 +27,14 @@ PowerShell Core does not work with PowerShell ISE. To replicate the ISE experien
 
 ## CluedIn product toolkit
 
-|Version| Technical Version | Source Code  | Link |
-|--|--|--|
-|2024.12.01 | 4.4.1 | [Source Code](https://github.com/CluedIn-io/CluedIn.Product.Toolkit/tree/release/4.4.1) | <a href="/assets/other/CluedIn.Product.Toolkit_4.4.1.zip" download>Download</a> |
-|2024.12.00 | 4.4.0 | [Source Code](https://github.com/CluedIn-io/CluedIn.Product.Toolkit/tree/release/4.4.0) | <a href="/assets/other/CluedIn.Product.Toolkit_4.4.0.zip" download>Download</a> |
-|2024.07 | 4.3.0 | [Source Code](https://github.com/CluedIn-io/CluedIn.Product.Toolkit/tree/release/4.3.0) | <a href="/assets/other/CluedIn.Product.Toolkit_0.9.35.zip" download>Download</a> |
+Please find the latest releases on our [GitHub repository](https://github.com/CluedIn-io/CluedIn.Product.Toolkit/releases)
+
+All future versions will be published on the [CluedIn.Product.Toolkit](https://github.com/CluedIn-io/CluedIn.Product.Toolkit) repository. Make sure that you retrieve the version that relates to the version of CluedIn that you are running.
+
+| Version | Technical Version | Source Code  | Link |
+| -- | -- | -- |
+| 2024.12.00 | 4.4.0 | [Source Code](https://github.com/CluedIn-io/CluedIn.Product.Toolkit/tree/release/4.4.0) | <a href="/assets/other/CluedIn.Product.Toolkit_4.4.0.zip" download>Download</a> |
+| 2024.07 | 4.3.0 | [Source Code](https://github.com/CluedIn-io/CluedIn.Product.Toolkit/tree/release/4.3.0) | <a href="/assets/other/CluedIn.Product.Toolkit_0.9.35.zip" download>Download</a> |
 
 The product toolkit supports a number of methods of transferring configuration from one environment to another. The main two methods are running locally on your desktop or using a pipeline platform such as Azure DevOps. Below will guide you through both local and Azure DevOps, but you can technically use other methods.
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
The migration script. Is now being released directly on the repository. So we want to direct people to the repository to get the release instead of listing each version on the page
