### PR TITLE
Fix typo in local install guide

### DIFF
--- a/docs/020-deployment/local/020-local-install-guide.md
+++ b/docs/020-deployment/local/020-local-install-guide.md
@@ -191,7 +191,7 @@ When the nip.io domain does not work, do the following:
 1. Replace the line that you found in step 2 with the following line:
 
     ```
-    CLUEDIN_DOMAIN=clueidn.local
+    CLUEDIN_DOMAIN=cluedin.local
     ```
 
 ## Results


### PR DESCRIPTION
Fix typo:

```
 CLUEDIN_DOMAIN=clueidn.local
```

to

```
 CLUEDIN_DOMAIN=cluedin.local
```