### PR TITLE
Improve relations documentation with troubleshooting and examples

### DIFF
--- a/docs/010-getting-started/090-relations.md
+++ b/docs/010-getting-started/090-relations.md
@@ -13,6 +13,11 @@ tags: ["getting-started"]
 
 Relations are built between source ("to") and target ("from") records by using edges of a certain type (for example, /WorksFor). You can create relations either before or after processing the data.
 
+> **Note**  
+> The terms "from" and "to" can be confusing.  
+> - **From** refers to the record in the current dataset  
+> - **To** refers to the existing record you are linking to
+
 <div class="videoFrame">
 <iframe src="https://player.vimeo.com/video/854717569?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" title="Getting started with relations in CluedIn"></iframe>
 </div>
@@ -33,9 +38,34 @@ Before proceeding with relations between golden records, ensure that you have co
 
 1. Uploaded and mapped the data that you will be linking to already existing records. You can use file 2 above. See [Import file](/getting-started/data-ingestion#import-file) and [Create mapping](/getting-started/data-ingestion#create-mapping).
 
+## Understanding relations in CluedIn
+
+In CluedIn, relations are represented as edges in a graph, linking one record to another.
+
+Each relation:
+- Has a direction (from → to)
+- Uses an edge type (for example, `/WorksFor`)
+- Connects records across business domains
+
+Relations enable:
+- Navigation between related records
+- Graph visualisation of connected data
+- More meaningful insights across entities
+
 ## Add edge relations
 
 After you imported and mapped the data that you will be linking to already existing records, edit the mapping configuration.
+
+### Example
+
+If your dataset contains employees and includes a company identifier, you can:
+
+- Create an edge type `/WorksFor`
+- Link each employee record to a company record
+
+This allows you to:
+- See which employees belong to which company
+- Navigate between related records in CluedIn
 
 **To add edge relations**
 
@@ -65,7 +95,7 @@ After you imported and mapped the data that you will be linking to already exist
 
     1. Find and select the target business domain to which you will link the records from the current data set.
 
-    1. Define the origin of the target data set. It will displayed after you process the data.
+    1. Define the origin of the target data set. It will be displayed after the data has been processed.
 
         ![entity-mapping-2.png]({{ "/assets/images/getting-started/relations/entity-mapping-2.png" | relative_url }})
 
@@ -94,6 +124,83 @@ After you processed the data and streamed the records, you can view the relation
     ![view-relations-3.png]({{ "/assets/images/getting-started/relations/view-relations-3.png" | relative_url }})
 
     If you add more edge relations between the records, CluedIn will automatically identify the changes and update the stream with new edge relations.
+
+## Troubleshooting relations (edges not appearing)
+
+In some cases, relations may appear correctly in the mapping preview but are not visible in the graph or entity view after processing.
+
+This section outlines common causes and validation steps.
+
+### How relations are created
+
+Relations are created when:
+
+- A valid identifier reference is provided in mapping
+- The referenced entity already exists in CluedIn
+- The dataset has been processed (or reprocessed after changes)
+
+#### Example identifier reference
+
+`/Organization#CRM:123`
+
+The reference must match an existing identifier on the target entity exactly.
+
+### Preview vs persisted relations
+
+The mapping preview validates configuration only.
+
+Relations are only persisted and visible in the graph after the dataset has been processed.
+
+This means a relation shown in preview may not appear in the graph if the required conditions are not met.
+
+### Common configuration considerations
+
+#### Identifier mismatch
+
+The target reference must match an existing identifier exactly, including:
+
+- Entity type
+- Origin
+- Value
+
+If any part differs, the relation will not be created.
+
+#### Target entity not available
+
+If the referenced entity does not exist in CluedIn at the time of processing, the relation will not be created.
+
+Ensure that:
+
+- The target dataset has been ingested
+- The data has been successfully processed
+
+#### Origin misalignment
+
+Relations rely on identifiers, which include origin as part of their structure.
+
+If the origin used in the relation does not match the origin used when creating the target entity, the identifiers will not align and the relation will not be created.
+
+#### Reprocessing requirement
+
+Changes to mapping (including relations) require the dataset to be reprocessed.
+
+Preview alone does not create relations in the graph.
+
+### Validation steps
+
+To verify relations:
+
+1. Confirm the target entity exists and is searchable
+2. Verify the identifier format matches exactly
+3. Confirm the origin is consistent across datasets
+4. Reprocess the dataset after applying mapping changes
+5. Check the entity view for the relation
+
+### Summary
+
+Relations in CluedIn depend on correct identifier alignment across datasets.
+
+If identifiers do not match exactly, relations will not be created, even if the mapping appears correct in preview.
 
 ## Results & next steps
 

--- a/docs/010-getting-started/090-relations.md
+++ b/docs/010-getting-started/090-relations.md
@@ -14,7 +14,7 @@ tags: ["getting-started"]
 Relations are built between source ("to") and target ("from") records by using edges of a certain type (for example, /WorksFor). You can create relations either before or after processing the data.
 
 > **Note**  
-> The terms "from" and "to" can be confusing.  
+> In this context:  
 > - **From** refers to the record in the current dataset  
 > - **To** refers to the existing record you are linking to
 


### PR DESCRIPTION
## Summary

Improves the relations documentation by adding clearer explanations, an example, and troubleshooting guidance.

## Changes

- Added a simple explanation of how relations work in CluedIn  
- Clarified the meaning of "from" and "to"  
- Added a practical example (e.g. `/WorksFor`)  
- Added troubleshooting steps for when relations do not appear after processing  
- Included basic checks to help diagnose issues  
- Made small wording improvements for clarity  

## Why this change

The existing documentation explains the steps well, but does not cover:

- How relations work in practice  
- Why relations might not appear after processing  
- Common issues with identifiers, origin, and processing  

These updates make the page easier to understand and help users resolve issues more quickly.