### PR TITLE
chore(dev): improve local development setup with cached mounts and VS Code task

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,10 @@
 {
 	"name": "Jekyll",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/jekyll:2-bullseye"
+	"image": "mcr.microsoft.com/devcontainers/jekyll:2-bullseye",
+
+	// Jekyll is read heavy, speedup subsequent builds by enabling cached mounts
+	"workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "start-server",
+            "type": "shell",
+            "command": "bundle exec jekyll serve --host 0.0.0.0 --livereload --watch --incremental --verbose --destination /tmp/_site --disable-disk-cache --force_polling --profile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "isBackground": true,
+            "problemMatcher": [],
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# CluedIn Documentation
+
+Jekyll-based documentation site for CluedIn.
+
+## Prerequisites
+
+- [Docker](https://www.docker.com/) and [VS Code](https://code.visualstudio.com/) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+## Getting started
+
+1. Open the repository in VS Code.
+2. When prompted, click **Reopen in Container** (or run **Dev Containers: Reopen in Container** from the command palette).
+3. The container will build and install all Ruby gem dependencies automatically.
+
+## Running the development server
+
+### Via VS Code task (recommended)
+
+Press `Ctrl+Shift+B` (or run **Tasks: Run Build Task**) to start the Jekyll development server. The site will be available at `http://localhost:4000`.
+
+The task uses incremental builds and live reload, so the browser will refresh automatically when files change.
+
+### Via terminal
+
+```bash
+bundle exec jekyll serve --host 0.0.0.0 --livereload --watch --incremental --destination /tmp/_site --force_polling
+```
+
+### Via Make
+
+```bash
+make serve
+```
+
+## Building the site
+
+To do a one-off build without starting the server:
+
+```bash
+bundle exec jekyll build
+```
+
+The output is written to `_site/` by default (or `/tmp/_site` when using the VS Code task).
+
+## Installing/updating dependencies
+
+```bash
+bundle install      # install gems from Gemfile.lock
+bundle update       # update gems to latest allowed versions
+```
+
+## Build performance
+
+Expect each build to take **~60 seconds**, even with `--incremental` and even when only a single file has changed.
+
+The root cause is `jekyll-remote-theme`. Jekyll's incremental build mode only skips re-rendering a page if none of its dependencies have changed. Because the remote theme's layout files (`_layouts/default.html`, `_includes/head.html`, `_includes/css/activation.scss.liquid`, etc.) are dependencies of every page, any change — including to the remote theme cache itself — causes all 416 pages to be re-rendered.
+
+The top render hotspots (from `--profile`) are all remote theme files:
+
+| Template | Pages rendered | Time (s) |
+|---|---|---|
+| `_layouts/default.html` | 416 | 26.7 |
+| `_includes/head.html` | 416 | 18.5 |
+| `_includes/css/activation.scss.liquid` | 416 | 17.6 |
+
+There is no simple workaround without changing the theme strategy (e.g. switching from `jekyll-remote-theme` to a locally vendored copy of the theme).


### PR DESCRIPTION
## Summary

Improves the local development experience when working in the dev container.

## Changes

- **`.devcontainer/devcontainer.json`**: Adds `workspaceMount` with `consistency=cached` to speed up filesystem operations in the dev container. Jekyll is read-heavy during builds, so cached bind mounts reduce I/O overhead.

- **`.vscode/tasks.json`**: Adds a default build task (`Ctrl+Shift+B`) that runs the Jekyll development server with flags suited for the dev container environment (`--host 0.0.0.0`, `--force_polling`, `--incremental`, `--livereload`, `--destination /tmp/_site`).

## Notes

Builds currently take ~60s even with `--incremental` due to `jekyll-remote-theme` causing all 416 pages to re-render on every change. This is a known limitation documented in `README.md`.